### PR TITLE
Release Version 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog Application Jobsearch
 ===============================
 ## 1.6.1
 * Adds ML enriched locations to typeahead
+* Fixes a bug that wouldn't display number of ads for municipalities and regions in taxonomy search.
 
 ## 1.6.0
 * Introduces new lowercase type for request parsing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog Application Jobsearch
 ===============================
+## 1.6.1
+* Adds ML enriched locations to typeahead
+
 ## 1.6.0
 * Introduces new lowercase type for request parsing
 * Fixes a bug in context-unaware typeahead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 Changelog Application Jobsearch
 ===============================
+
 ## 1.6.1
 * Adds ML enriched locations to typeahead
 * Fixes a bug that wouldn't display number of ads for municipalities and regions in taxonomy search.
+* Adds header x-feature-include-synonyms-typeahead for choosing if enriched synonyms should be included in typeahead.
 
 ## 1.6.0
 * Introduces new lowercase type for request parsing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog Application Jobsearch
 ===============================
 
-## 1.6.1
+## 1.7.0
 * Adds ML enriched locations to typeahead
 * Fixes a bug that wouldn't display number of ads for municipalities and regions in taxonomy search.
 * Adds header x-feature-include-synonyms-typeahead for choosing if enriched synonyms should be included in typeahead.

--- a/bulkloader/rest/__init__.py
+++ b/bulkloader/rest/__init__.py
@@ -1,7 +1,7 @@
 from flask_restplus import Api, Namespace, reqparse, inputs
 from sokannonser import settings
 
-api = Api(version='1.6.1', title='Download job ads',
+api = Api(version='1.7.0', title='Download job ads',
           description='An API for retrieving job ads',
           default='bulkloader',
           default_label="An API for retrieving job ads.")

--- a/bulkloader/rest/__init__.py
+++ b/bulkloader/rest/__init__.py
@@ -1,7 +1,7 @@
 from flask_restplus import Api, Namespace, reqparse, inputs
 from sokannonser import settings
 
-api = Api(version='1.6.0', title='Download job ads',
+api = Api(version='1.6.1', title='Download job ads',
           description='An API for retrieving job ads',
           default='bulkloader',
           default_label="An API for retrieving job ads.")

--- a/nginx.conf
+++ b/nginx.conf
@@ -111,7 +111,7 @@ http {
 
           if ($request_method = 'OPTIONS') {
               # add_header 'Content-Length' 0;
-              add_header 'Access-Control-Allow-Headers' 'api-key, x-feature-freetext-bool-method, x-feature-allow-empty-typeahead';
+              add_header 'Access-Control-Allow-Headers' 'api-key, x-feature-*';
               # Tell client that this pre-flight info is valid for 6 months
               add_header 'Access-Control-Max-Age' 2592000;
               add_header 'Access-Control-Allow-Origin' '*';

--- a/nginx.conf
+++ b/nginx.conf
@@ -111,7 +111,7 @@ http {
 
           if ($request_method = 'OPTIONS') {
               # add_header 'Content-Length' 0;
-              add_header 'Access-Control-Allow-Headers' 'api-key, x-feature-*';
+              add_header 'Access-Control-Allow-Headers' 'api-key, x-feature-freetext-bool-method, x-feature-allow-empty-typeahead, x-feature-include-synonyms-typeahead';
               # Tell client that this pre-flight info is valid for 6 months
               add_header 'Access-Control-Max-Age' 2592000;
               add_header 'Access-Control-Allow-Origin' '*';

--- a/sokannonser/repository/ontology.py
+++ b/sokannonser/repository/ontology.py
@@ -118,7 +118,6 @@ class Ontology(object):
         found_locations = [p['key'] for p in ext_buckets if not p['key'].isnumeric()]
         self.extracted_locations = set(found_locations)
         found_locations.extend([p['key'] for p in enr_buckets if not p['key'].isnumeric()])
-        print("LOCATIONS", found_locations)
         return set(found_locations)
 
     @staticmethod

--- a/sokannonser/repository/ontology.py
+++ b/sokannonser/repository/ontology.py
@@ -26,7 +26,7 @@ class Ontology(object):
         self.concept_to_term = {}
         self.keyword_processor = KeywordProcessor()
         self.init_keyword_processor(self.keyword_processor)
-        self.extracted_locations = set()
+        self.locations = set()
         self.init_ontology(self.keyword_processor)
 
     def __len__(self):
@@ -55,9 +55,9 @@ class Ontology(object):
                 self.concept_to_term[concept_preferred_label] = []
             self.concept_to_term[concept_preferred_label].append(term_obj)
 
-        self.extracted_locations = self._load_locations_from_extracted()
+        self.locations = self._load_locations()
 
-        for place in self.extracted_locations:
+        for place in self.locations:
             # Only complete keyword_processor with locations that are missing
             # in narvalontology but exists in the ads, to avoid conflicts.
             if not keyword_processor.get_keyword(place):
@@ -66,16 +66,22 @@ class Ontology(object):
                              'type': ttc.TextToConcept.LOCATION_KEY}
                 keyword_processor.add_keyword(place, place_obj)
 
-    def _load_locations_from_extracted(self):
+    def _load_locations(self):
         # Load locations
         query = {
             "aggs": {
-                "locations": {
+                "ext_locations": {
                     "terms": {
                         "field": "%s.location.raw" % fields.KEYWORDS_EXTRACTED,
                         "size": 20000
                     }
-                }
+                },
+                "enr_locations": {
+                    "terms": {
+                        "field": "%s.location.raw" % fields.KEYWORDS_ENRICHED,
+                        "size": 20000
+                    }
+                },
             },
             "query": {
                 "bool": {
@@ -106,9 +112,12 @@ class Ontology(object):
             "size": 0
         }
         results = self.client.search(body=query, index=self.annons_index)
-        buckets = results.get('aggregations', {}).get('locations', {}).get('buckets', [])
-        extracted_locations = [p['key'] for p in buckets if not p['key'].isnumeric()]
-        return set(extracted_locations)
+        ext_buckets = results.get('aggregations', {}).get('ext_locations', {}).get('buckets', [])
+        enr_buckets = results.get('aggregations', {}).get('enr_locations', {}).get('buckets', [])
+        found_locations = [p['key'] for p in ext_buckets if not p['key'].isnumeric()]
+        found_locations.extend([p['key'] for p in enr_buckets if not p['key'].isnumeric()])
+        print("LOCATIONS", found_locations)
+        return set(found_locations)
 
     @staticmethod
     def init_keyword_processor(keyword_processor):

--- a/sokannonser/repository/ontology.py
+++ b/sokannonser/repository/ontology.py
@@ -66,7 +66,6 @@ class Ontology(object):
                              'type': ttc.TextToConcept.LOCATION_KEY}
                 keyword_processor.add_keyword(place, place_obj)
 
-
     def _load_locations_from_extracted(self):
         # Load locations
         query = {

--- a/sokannonser/repository/ontology.py
+++ b/sokannonser/repository/ontology.py
@@ -27,6 +27,7 @@ class Ontology(object):
         self.keyword_processor = KeywordProcessor()
         self.init_keyword_processor(self.keyword_processor)
         self.locations = set()
+        self.extracted_locations = set()
         self.init_ontology(self.keyword_processor)
 
     def __len__(self):
@@ -115,6 +116,7 @@ class Ontology(object):
         ext_buckets = results.get('aggregations', {}).get('ext_locations', {}).get('buckets', [])
         enr_buckets = results.get('aggregations', {}).get('enr_locations', {}).get('buckets', [])
         found_locations = [p['key'] for p in ext_buckets if not p['key'].isnumeric()]
+        self.extracted_locations = set(found_locations)
         found_locations.extend([p['key'] for p in enr_buckets if not p['key'].isnumeric()])
         print("LOCATIONS", found_locations)
         return set(found_locations)

--- a/sokannonser/repository/platsannonser.py
+++ b/sokannonser/repository/platsannonser.py
@@ -65,7 +65,7 @@ def get_stats_for(taxonomy_type):
         },
         "aggs": {
             "antal_annonser": {
-                "terms": {"field": value_path[taxonomy_type[0]], "size": 50},
+                "terms": {"field": value_path[taxonomy_type[0]], "size": 5000},
             }
         }
     }

--- a/sokannonser/repository/platsannonser.py
+++ b/sokannonser/repository/platsannonser.py
@@ -26,8 +26,8 @@ def get_stats_for(taxonomy_type):
             fields.OCCUPATION_FIELD, fields.LEGACY_AMS_TAXONOMY_ID),
         taxonomy.SKILL: "%s.%s.keyword" % (fields.MUST_HAVE_SKILLS,
                                            fields.LEGACY_AMS_TAXONOMY_ID),
-        taxonomy.MUNICIPALITY: "%s.keyword" % fields.WORKPLACE_ADDRESS_MUNICIPALITY,
-        taxonomy.REGION: "%s.keyword" % fields.WORKPLACE_ADDRESS_REGION
+        taxonomy.MUNICIPALITY: "%s" % fields.WORKPLACE_ADDRESS_MUNICIPALITY_CODE,
+        taxonomy.REGION: "%s" % fields.WORKPLACE_ADDRESS_REGION_CODE
     }
     # Make sure we don't crash if we want to stat on missing type
     for tt in taxonomy_type:

--- a/sokannonser/repository/querybuilder.py
+++ b/sokannonser/repository/querybuilder.py
@@ -240,9 +240,12 @@ class QueryBuilder(object):
    
             size = 12/len(complete_fields)
 
+            enriched_typeahead_field = f.KEYWORDS_ENRICHED_SYNONYMS if args.get(
+                settings.X_FEATURE_INCLUDE_SYNONYMS_TYPEAHEAD) else f.KEYWORDS_ENRICHED
+
             for field in complete_fields:
                 base_field = f.KEYWORDS_EXTRACTED \
-                    if field in ['employer'] else f.KEYWORDS_ENRICHED
+                    if field in ['employer'] else enriched_typeahead_field
 
                 if complete or args.get(settings.X_FEATURE_ALLOW_EMPTY_TYPEAHEAD):
                     query_dsl['aggs']["complete_00_%s" % field] = {

--- a/sokannonser/rest/__init__.py
+++ b/sokannonser/rest/__init__.py
@@ -1,6 +1,6 @@
 from flask_restplus import Api, Namespace
 
-api = Api(version='1.6.1', title='Search job ads',
+api = Api(version='1.7.0', title='Search job ads',
           description='An API for searching and retrieving job ads and for finding '
           'concepts in the Jobtech Taxonomy.',
           default='sokannonser',

--- a/sokannonser/rest/__init__.py
+++ b/sokannonser/rest/__init__.py
@@ -1,6 +1,6 @@
 from flask_restplus import Api, Namespace
 
-api = Api(version='1.6.0', title='Search job ads',
+api = Api(version='1.6.1', title='Search job ads',
           description='An API for searching and retrieving job ads and for finding '
           'concepts in the Jobtech Taxonomy.',
           default='sokannonser',

--- a/sokannonser/rest/endpoint/platsannonser.py
+++ b/sokannonser/rest/endpoint/platsannonser.py
@@ -102,6 +102,7 @@ class PBComplete(Resource):
             settings.CONTEXTUAL_TYPEAHEAD: "Set to false to disable contextual typeahead"
                                            " (default: true)",
             settings.X_FEATURE_ALLOW_EMPTY_TYPEAHEAD: "Allow empty querystring in typeahead.",
+            settings.X_FEATURE_INCLUDE_SYNONYMS_TYPEAHEAD: "Include enriched synonyms in typeahead.",
             **swagger_doc_params
         }
     )

--- a/sokannonser/rest/model/fields.py
+++ b/sokannonser/rest/model/fields.py
@@ -71,6 +71,7 @@ REMOVED_DATE = 'removed_date'
 SOURCE_TYPE = 'source_type'
 
 KEYWORDS_ENRICHED = 'keywords.enriched'
+KEYWORDS_ENRICHED_SYNONYMS = 'keywords.enriched_synonyms'
 KEYWORDS_EXTRACTED = 'keywords.extracted'
 
 sort_options = {

--- a/sokannonser/rest/model/queries.py
+++ b/sokannonser/rest/model/queries.py
@@ -141,6 +141,9 @@ annons_complete_query.add_argument(settings.CONTEXTUAL_TYPEAHEAD, type=inputs.bo
 annons_complete_query.add_argument(settings.X_FEATURE_ALLOW_EMPTY_TYPEAHEAD,
                                    type=inputs.boolean, location='headers',
                                    required=False)
+annons_complete_query.add_argument(settings.X_FEATURE_INCLUDE_SYNONYMS_TYPEAHEAD,
+                                   type=inputs.boolean, location='headers',
+                                   required=False)
 
 
 pb_query = base_annons_query.copy()

--- a/sokannonser/settings.py
+++ b/sokannonser/settings.py
@@ -40,6 +40,7 @@ APIKEY = 'api-key'
 # Feature toggles
 X_FEATURE_FREETEXT_BOOL_METHOD = 'x-feature-freetext-bool-method'
 X_FEATURE_ALLOW_EMPTY_TYPEAHEAD = 'x-feature-allow-empty-typeahead'
+X_FEATURE_INCLUDE_SYNONYMS_TYPEAHEAD = 'x-feature-include-synonyms-typeahead'
 
 # Query parameters
 OFFSET = 'offset'

--- a/tests/integration_tests/test_platsannonser_complete.py
+++ b/tests/integration_tests/test_platsannonser_complete.py
@@ -1,0 +1,83 @@
+import os
+import sys
+
+import pytest
+
+from sokannonser import app
+from sokannonser import settings
+
+test_api_key = os.getenv('TEST_API_KEY')
+
+
+@pytest.mark.skip(reason="Temporarily disabled, needs values in field keywords.enriched_synonyms")
+@pytest.mark.integration
+def test_complete_one_param_occupation():
+    print('==================', sys._getframe().f_code.co_name, '================== ')
+
+    app.testing = True
+    with app.test_client() as testclient:
+        headers = {'api-key': test_api_key, 'accept': 'application/json',
+                   settings.X_FEATURE_INCLUDE_SYNONYMS_TYPEAHEAD: 'true'}
+        result = testclient.get('/complete', headers=headers, data={'q': 'servi'})
+        json_response = result.json
+        # pprint(json_response)
+        assert 'typeahead' in json_response
+        json_typeahead = json_response['typeahead']
+
+        complete_values = [item['value'] for item in json_typeahead]
+
+        assert len(complete_values) > 0
+        # pprint(complete_values)
+        assert 'servitris' in complete_values
+
+
+@pytest.mark.skip(reason="Temporarily disabled, needs values in field keywords.enriched_synonyms")
+@pytest.mark.integration
+def test_complete_one_param_competence():
+    print('==================', sys._getframe().f_code.co_name, '================== ')
+
+    app.testing = True
+    with app.test_client() as testclient:
+        headers = {'api-key': test_api_key, 'accept': 'application/json',
+                   settings.X_FEATURE_INCLUDE_SYNONYMS_TYPEAHEAD: 'true'}
+        result = testclient.get('/complete', headers=headers, data={'q': 'angu',
+                                                                    'limit': '0'})
+        json_response = result.json
+        # pprint(json_response)
+        assert 'typeahead' in json_response
+        json_typeahead = json_response['typeahead']
+
+        complete_values = [item['value'] for item in json_typeahead]
+
+        assert len(complete_values) > 0
+        # pprint(complete_values)
+        assert 'angular' in complete_values
+        assert 'angularjs' in complete_values
+
+
+@pytest.mark.skip(reason="Temporarily disabled, needs values in field keywords.enriched_synonyms")
+@pytest.mark.integration
+def test_complete_two_params():
+    print('==================', sys._getframe().f_code.co_name, '================== ')
+
+    app.testing = True
+    with app.test_client() as testclient:
+        headers = {'api-key': test_api_key, 'accept': 'application/json',
+                   settings.X_FEATURE_INCLUDE_SYNONYMS_TYPEAHEAD: 'true'}
+        result = testclient.get('/complete', headers=headers, data={'q': 'systemutvecklare angu',
+                                                                    'limit': '0'})
+        json_response = result.json
+        # pprint(json_response)
+        assert 'typeahead' in json_response
+        json_typeahead = json_response['typeahead']
+
+        complete_values = [item['value'] for item in json_typeahead]
+
+        assert len(complete_values) > 0
+        # pprint(complete_values)
+        assert 'angular' in complete_values
+        assert 'angularjs' in complete_values
+
+
+if __name__ == '__main__':
+    pytest.main([os.path.realpath(__file__), '-svv', '-ra', '-m integration'])


### PR DESCRIPTION
## 1.7.0
* Adds ML enriched locations to typeahead
* Fixes a bug that wouldn't display number of ads for municipalities and regions in taxonomy search.
* Adds header x-feature-include-synonyms-typeahead for choosing if enriched synonyms should be included in typeahead.