### PR TITLE
Activates fetch of type ahead terms from field keywords.enriched_type…

### DIFF
--- a/sokannonser/rest/model/fields.py
+++ b/sokannonser/rest/model/fields.py
@@ -71,7 +71,7 @@ REMOVED_DATE = 'removed_date'
 SOURCE_TYPE = 'source_type'
 
 KEYWORDS_ENRICHED = 'keywords.enriched'
-KEYWORDS_ENRICHED_SYNONYMS = 'keywords.enriched_synonyms'
+KEYWORDS_ENRICHED_SYNONYMS = 'keywords.enriched_typeahead_terms'
 KEYWORDS_EXTRACTED = 'keywords.extracted'
 
 sort_options = {


### PR DESCRIPTION
Activates fetch of type ahead terms from field keywords.enriched_typeahead_terms when setting feature flag X_FEATURE_INCLUDE_SYNONYMS_TYPEAHEAD to true.
Should not be merged to Master branch before verification by PB and  https://github.com/JobtechSwe/elastic-importers has been merged to Master branch and a full import has been done.